### PR TITLE
Key Changes:

### DIFF
--- a/DataAcess/CustomExceptions/NotFoundException.cs
+++ b/DataAcess/CustomExceptions/NotFoundException.cs
@@ -1,0 +1,10 @@
+﻿
+namespace DataAcess.CustomExceptions
+{
+    public class NotFoundException : Exception
+    {
+        public NotFoundException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/DataAcess/Repos/UserRepository.cs
+++ b/DataAcess/Repos/UserRepository.cs
@@ -11,6 +11,7 @@ using Models.Const;
 using Models.Domain;
 using Models.DTOs.Auth;
 using Models.DTOs.User;
+using DataAcess.CustomExceptions;
 
 
 namespace DataAcess.Repos
@@ -43,7 +44,7 @@ namespace DataAcess.Repos
 		public async Task<ApplicationUser> GetUserByID(string userID)
 		{
 			var user = await db.ApplicationUser.Include(u => u.Image).FirstOrDefaultAsync(u => u.Id == userID);
-			return user ?? throw new InvalidOperationException("User not found.");
+			return user ?? throw new NotFoundException("User not found");
 		}
 
 		public async Task<bool> IsUniqueUserName(string username)

--- a/IdentityManagerAPI/Controllers/UsersController.cs
+++ b/IdentityManagerAPI/Controllers/UsersController.cs
@@ -39,7 +39,7 @@ namespace IdentityManagerAPI.Controllers
 		public async Task<IActionResult> GetUser([FromRoute] string id)
 		{
 			var user = await userService.GetById(id);
-			return Ok(user);
+            return Ok(user);
 		}
 
 		[HttpPost]


### PR DESCRIPTION
- The handler differentiates between exception types to return accurate HTTP status codes and responses (400 for validation, 404 for not found, 500 for server errors).
- Created a custom `NotFoundException` to be thrown from the repository/service layer, simplifying controller logic by removing the need for manual null checks.
- Integrated `IProblemDetailsService` to ensure all error responses are RFC 7807 compliant (`application/problem+json`).
- Added structured error details for `ValidationException` to improve the client-side developer experience.